### PR TITLE
Implement missing domain storage and hooks

### DIFF
--- a/packages/storage/lib/impl/githubApiDomainStorage.ts
+++ b/packages/storage/lib/impl/githubApiDomainStorage.ts
@@ -1,0 +1,17 @@
+import type { BaseStorage } from '../base/index.js';
+import { createStorage, StorageEnum } from '../base/index.js';
+
+/**
+ * Storage utility for GitHub API domain
+ */
+const storage = createStorage<string>('github-api-domain', 'https://api.github.com', {
+  storageEnum: StorageEnum.Local,
+  liveUpdate: true,
+});
+
+export const githubApiDomainStorage: BaseStorage<string> & { clear: () => Promise<void> } = {
+  ...storage,
+  clear: async () => {
+    await storage.set('https://api.github.com');
+  },
+};

--- a/packages/storage/lib/impl/index.ts
+++ b/packages/storage/lib/impl/index.ts
@@ -4,3 +4,5 @@ export * from './prChecklistStorage.js';
 export * from './openaiApiKeyStorage.js';
 export * from './languagePreferenceStorage.js';
 export * from './geminiApiKeyStorage.js';
+export * from './githubApiDomainStorage.js';
+export * from './openaiApiEndpointStorage.js';

--- a/packages/storage/lib/impl/openaiApiEndpointStorage.ts
+++ b/packages/storage/lib/impl/openaiApiEndpointStorage.ts
@@ -1,0 +1,17 @@
+import type { BaseStorage } from '../base/index.js';
+import { createStorage, StorageEnum } from '../base/index.js';
+
+/**
+ * Storage utility for OpenAI API endpoint
+ */
+const storage = createStorage<string>('openai-api-endpoint', 'https://api.openai.com/v1', {
+  storageEnum: StorageEnum.Local,
+  liveUpdate: true,
+});
+
+export const openaiApiEndpointStorage: BaseStorage<string> & { clear: () => Promise<void> } = {
+  ...storage,
+  clear: async () => {
+    await storage.set('https://api.openai.com/v1');
+  },
+};

--- a/pages/side-panel/src/hooks/useGithubApiDomainAtom.ts
+++ b/pages/side-panel/src/hooks/useGithubApiDomainAtom.ts
@@ -1,0 +1,35 @@
+import { atom, useAtom } from 'jotai';
+import { useEffect } from 'react';
+import { githubApiDomainStorage } from '@extension/storage';
+
+// jotai atom: 初期値はnull、ロード時にstorageから取得
+const githubApiDomainAtom = atom<string>('https://api.github.com');
+
+export function useGithubApiDomainAtom() {
+  const [githubDomain, setGithubDomain] = useAtom(githubApiDomainAtom);
+
+  // 初回マウント時にstorageから値を取得
+  useEffect(() => {
+    let mounted = true;
+    githubApiDomainStorage.get().then(val => {
+      if (mounted) setGithubDomain(val);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [setGithubDomain]);
+
+  // setter: jotai atomとstorage両方を更新
+  const setDomainAndStorage = async (newDomain: string) => {
+    await githubApiDomainStorage.set(newDomain);
+    setGithubDomain(newDomain);
+  };
+
+  // remover: デフォルト値にリセット
+  const clearDomain = async () => {
+    await githubApiDomainStorage.clear();
+    setGithubDomain('https://api.github.com');
+  };
+
+  return { githubDomain, setDomainAndStorage, clearDomain } as const;
+}

--- a/pages/side-panel/src/hooks/useOpenaiDomainAtom.ts
+++ b/pages/side-panel/src/hooks/useOpenaiDomainAtom.ts
@@ -1,0 +1,35 @@
+import { atom, useAtom } from 'jotai';
+import { useEffect } from 'react';
+import { openaiApiEndpointStorage } from '@extension/storage';
+
+// jotai atom: 初期値はundefined、ロード時にstorageから取得
+export const openaiDomainAtom = atom<string>('https://api.openai.com/v1');
+const isOpenaiDomainLoadedAtom = atom<boolean>(false);
+
+export function useOpenaiDomainAtom() {
+  const [openaiDomain, setOpenaiDomain] = useAtom(openaiDomainAtom);
+  const [isOpenaiDomainLoaded, setIsOpenaiDomainLoaded] = useAtom(isOpenaiDomainLoadedAtom);
+
+  useEffect(() => {
+    let mounted = true;
+    openaiApiEndpointStorage.get().then(val => {
+      if (mounted) setOpenaiDomain(val);
+      setIsOpenaiDomainLoaded(true);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [setOpenaiDomain, setIsOpenaiDomainLoaded]);
+
+  const setDomainAndStorage = async (newDomain: string) => {
+    await openaiApiEndpointStorage.set(newDomain);
+    setOpenaiDomain(newDomain);
+  };
+
+  const clearDomain = async () => {
+    await openaiApiEndpointStorage.clear();
+    setOpenaiDomain('https://api.openai.com');
+  };
+
+  return { openaiDomain, setDomainAndStorage, clearDomain, isOpenaiDomainLoaded } as const;
+}


### PR DESCRIPTION
## Summary
- add githubApiDomainStorage and openaiApiEndpointStorage
- export them in storage impl index
- implement useGithubApiDomainAtom hook
- implement useOpenaiDomainAtom hook

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685f3e792910832b84b1de6be6761f4a