### PR TITLE
Fix toast language after language switch

### DIFF
--- a/pages/side-panel/src/views/SettingsView.tsx
+++ b/pages/side-panel/src/views/SettingsView.tsx
@@ -24,6 +24,7 @@ const SettingsView: React.FC = () => {
     message: '',
     type: 'success',
   });
+  const [pendingLanguageToast, setPendingLanguageToast] = useState(false);
   // modelClientTypeのJotai hooksを利用
   const { modelClientType, setTypeAndStorage } = useModelClientTypeAtom();
   // Geminiエンドポイント有効判定
@@ -69,10 +70,17 @@ const SettingsView: React.FC = () => {
     setToast(prev => ({ ...prev, visible: false }));
   };
 
+  useEffect(() => {
+    if (pendingLanguageToast) {
+      showToast(t('settingsSavedSuccess'), 'success');
+      setPendingLanguageToast(false);
+    }
+  }, [pendingLanguageToast, t]);
+
   const handleLanguageChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newLanguage = e.target.value as Language;
     await setLanguage(newLanguage);
-    showToast(t('settingsSavedSuccess'), 'success');
+    setPendingLanguageToast(true);
   };
 
   // handleModelClientTypeChangeをhooks経由に


### PR DESCRIPTION
## Summary
- show toast after language state updates so the translation uses the new language

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68711e485b80832b87be4e8624b8a5a4