### PR TITLE
Add i18n for loading and error messages

### DIFF
--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -13,6 +13,9 @@
   "loading": {
     "message": "Loading..."
   },
+  "error": {
+    "message": "Error!"
+  },
   "greeting": {
     "description": "Greeting message",
     "message": "Hello, my name is $NAME$",

--- a/packages/i18n/locales/ja/messages.json
+++ b/packages/i18n/locales/ja/messages.json
@@ -13,6 +13,9 @@
   "loading": {
     "message": "読み込み中..."
   },
+  "error": {
+    "message": "エラー！"
+  },
   "greeting": {
     "description": "挨拶メッセージ",
     "message": "こんにちは、私の名前は$NAME$です",

--- a/packages/i18n/locales/ko/messages.json
+++ b/packages/i18n/locales/ko/messages.json
@@ -13,6 +13,9 @@
   "loading": {
     "message": "로딩 중..."
   },
+  "error": {
+    "message": "오류!"
+  },
   "greeting": {
     "description": "인사 메시지",
     "message": "안녕하세요, 제 이름은 $NAME$입니다.",

--- a/packages/i18n/locales/zh/messages.json
+++ b/packages/i18n/locales/zh/messages.json
@@ -13,6 +13,9 @@
   "loading": {
     "message": "加载中..."
   },
+  "error": {
+    "message": "错误！"
+  },
   "greeting": {
     "description": "问候消息",
     "message": "你好，我叫$NAME$",

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -6,9 +6,19 @@ import AppRouter from './routes/AppRoutes';
 import { currentPageAtom } from './atoms/currentPageAtom';
 import { useI18n } from '@extension/i18n';
 
+const Loading = () => {
+  const { t } = useI18n();
+  return <div>{t('loading')}</div>;
+};
+
+const ErrorFallback = () => {
+  const { t } = useI18n();
+  return <div>{t('error')}</div>;
+};
+
 const SidePanel = () => {
   // Initialize i18n
-  useI18n();
+  const { t } = useI18n();
 
   const [loading, setLoading] = useState(true);
 
@@ -57,10 +67,10 @@ const SidePanel = () => {
   }, [setCurrentPageAtom]);
 
   if (loading) {
-    return <div>Loading...</div>;
+    return <div>{t('loading')}</div>;
   }
 
   return <AppRouter />;
 };
 
-export default withErrorBoundary(withSuspense(SidePanel, <div>Loading...</div>), <div>Error!</div>);
+export default withErrorBoundary(withSuspense(SidePanel, <Loading />), <ErrorFallback />);

--- a/pages/side-panel/src/views/GithubTokenSetupView.tsx
+++ b/pages/side-panel/src/views/GithubTokenSetupView.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
+import { useI18n } from '@extension/i18n';
 import { githubTokenStorage } from '@extension/storage';
 import { useNavigation } from '@src/context/NavigationContext';
 import { useOpenaiKeyAtom } from '@src/hooks/useOpenaiKeyAtom';
 
 const GithubTokenSetupView: React.FC = () => {
   const { navigateToHome, navigateToOpenAiTokenSetup } = useNavigation();
+  const { t } = useI18n();
 
   const [token, setToken] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -81,7 +83,7 @@ const GithubTokenSetupView: React.FC = () => {
               className={`px-4 py-2 rounded-md ${
                 isLoading ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-500 hover:bg-blue-600'
               } text-white`}>
-              {isLoading ? 'Verifying...' : 'Save Token'}
+              {isLoading ? t('verifying') : t('save')}
             </button>
           </div>
         </form>

--- a/pages/side-panel/src/views/OpenAiTokenSetupView.tsx
+++ b/pages/side-panel/src/views/OpenAiTokenSetupView.tsx
@@ -153,7 +153,7 @@ const OpenAiTokenSetupView: React.FC = () => {
               className={`px-4 py-2 rounded-md ${
                 isLoading ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-500 hover:bg-blue-600'
               } text-white`}>
-              {isLoading ? 'Verifying...' : 'Save Token'}
+              {isLoading ? t('verifying') : t('save')}
             </button>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- use translation function for loading states in SidePanel
- add generic error message translations
- replace hard-coded button labels with i18n strings

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: OpenOptions type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68711e6e2054832b8712de3a2c20abf4