### PR TITLE
Set English as default language

### DIFF
--- a/packages/storage/lib/impl/languagePreferenceStorage.ts
+++ b/packages/storage/lib/impl/languagePreferenceStorage.ts
@@ -4,7 +4,7 @@ import { createStorage, StorageEnum } from '../base/index.js';
 // Define the supported languages
 export type Language = 'en' | 'ja' | 'ko' | 'zh';
 
-export const defaultLanguage: Language = 'ja';
+export const defaultLanguage: Language = 'en';
 
 export const getLanguageLabel = (lang: Language): string => {
   switch (lang) {


### PR DESCRIPTION
## Summary
- switch default language constant from Japanese to English

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: OpenOptions type mismatch in chrome-extension)*

------
https://chatgpt.com/codex/tasks/task_e_68712059e374832b93c3408a1b1f4732