### PR TITLE
Fix checkbox shrinking issue

### DIFF
--- a/pages/side-panel/src/components/FileChatModal.tsx
+++ b/pages/side-panel/src/components/FileChatModal.tsx
@@ -299,7 +299,7 @@ const FileChatModal: React.FC<FileChatModalProps> = ({
                                 setShowCompleteModal(true);
                               }
                             }}
-                            className="w-4 h-4 text-blue-600 border-gray-300 rounded"
+                            className="w-4 h-4 text-blue-600 border-gray-300 rounded shrink-0"
                           />
                           <span className="text-sm">
                             <MarkdownRenderer content={item.description} />

--- a/pages/side-panel/src/components/FileChecklist.tsx
+++ b/pages/side-panel/src/components/FileChecklist.tsx
@@ -45,7 +45,7 @@ const ChecklistItem = ({ label, isChecked, onToggle, className = '' }: Checklist
         type="checkbox"
         checked={isChecked}
         onChange={onToggle}
-        className="w-4 h-4 text-blue-600 border-gray-300 rounded"
+        className="w-4 h-4 text-blue-600 border-gray-300 rounded shrink-0"
       />
       <span className="text-sm">
         <MarkdownRenderer content={label} />


### PR DESCRIPTION
## Summary
- prevent checkbox shrinking when labels are long

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: command exited with code 2)*

------
https://chatgpt.com/codex/tasks/task_e_687130aa0bfc832b9efb0280d281cd24