### PR TITLE
Add i18n message for PR URL prompt

### DIFF
--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -307,6 +307,9 @@
   "generatingChecklistError": {
     "message": "Error occurred while generating the checklist."
   },
+  "enterPrUrlPrompt": {
+    "message": "Enter a GitHub Pull Request URL to generate an AI-powered review checklist."
+  },
   "openaiApiDesc": {
     "message": "To use PR Checklistify, you need to provide your OpenAI API key."
   },

--- a/packages/i18n/locales/ja/messages.json
+++ b/packages/i18n/locales/ja/messages.json
@@ -307,6 +307,9 @@
   "generatingChecklistError": {
     "message": "チェックリスト生成中にエラーが発生しました。"
   },
+  "enterPrUrlPrompt": {
+    "message": "AIによるレビュー チェックリストを生成するには、GitHubのPull Request URLを入力してください。"
+  },
   "openaiApiDesc": {
     "message": "PR Checklistifyを利用するには、OpenAI APIキーの提供が必要です。"
   },

--- a/packages/i18n/locales/ko/messages.json
+++ b/packages/i18n/locales/ko/messages.json
@@ -189,6 +189,9 @@
   "failedToLoadSettings": {
     "message": "저장된 설정을 불러오는데 실패했습니다"
   },
+  "enterPrUrlPrompt": {
+    "message": "AI 기반 검토 체크리스트를 생성하려면 GitHub Pull Request URL을 입력하세요."
+  },
   "openaiApiDesc": {
     "message": "PR Checklistify를 사용하려면 OpenAI API 키를 입력해야 합니다."
   },

--- a/packages/i18n/locales/zh/messages.json
+++ b/packages/i18n/locales/zh/messages.json
@@ -190,6 +190,9 @@
   "failedToLoadSettings": {
     "message": "无法加载保存的设置"
   },
+  "enterPrUrlPrompt": {
+    "message": "输入 GitHub Pull Request URL 以生成 AI 驱动的评审清单。"
+  },
   "openaiApiDesc": {
     "message": "要使用 PR Checklistify，您需要提供 OpenAI API 密钥。"
   },

--- a/pages/side-panel/src/views/DefaultView.tsx
+++ b/pages/side-panel/src/views/DefaultView.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
+import { useI18n } from '@extension/i18n';
 import { useNavigation } from '../context/NavigationContext';
 import { isGitHubPRPage, extractPRInfoFromKey } from '../utils/prUtils';
 
 const DefaultView: React.FC = () => {
+  const { t } = useI18n();
   const { navigateToPr, navigateToPrFromHistory } = useNavigation();
   const [prUrl, setPrUrl] = useState('');
   const [isValid, setIsValid] = useState(false);
@@ -63,9 +65,7 @@ const DefaultView: React.FC = () => {
     <div className="flex flex-col items-center justify-center min-h-screen p-6 bg-gray-50">
       <div className="bg-white p-6 rounded-lg shadow-md w-full max-w-xl">
         <h1 className="text-2xl font-bold mb-4 text-center">PR Checklistify</h1>
-        <p className="text-sm text-gray-600 mb-6 text-center">
-          Enter a GitHub Pull Request URL to generate an AI-powered review checklist.
-        </p>
+        <p className="text-sm text-gray-600 mb-6 text-center">{t('enterPrUrlPrompt')}</p>
 
         <div className="mb-6">
           <label htmlFor="pr-url" className="block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
## Summary
- translate the instruction text for entering a PR URL
- expose the new `enterPrUrlPrompt` key in all locales
- display this text via `t()` in the default view

## Testing
- `pnpm type-check` *(fails: OpenOptions windowId issue)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687138605ca4832ba4ec650a27c0251c