### PR TITLE
Adjust hover color for settings button

### DIFF
--- a/pages/side-panel/src/components/SettingsButton.tsx
+++ b/pages/side-panel/src/components/SettingsButton.tsx
@@ -10,7 +10,7 @@ const SettingsButton: React.FC<SettingsButtonProps> = ({ className = '' }) => {
   return (
     <button
       onClick={navigateToSettings}
-      className={`text-gray-600 hover:text-gray-800 focus:outline-none ${className}`}
+      className={`text-gray-600 hover:text-gray-200 focus:outline-none ${className}`}
       aria-label="Settings">
       <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path


### PR DESCRIPTION
## Summary
- lighten the settings button color on hover so it stays whitish instead of darkening

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68713e95fdb4832b89bfdc40a2a755d7