### PR TITLE
Add i18n for AI provider texts

### DIFF
--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -55,6 +55,12 @@
   "githubIntegration": {
     "message": "GitHub Integration"
   },
+  "aiProvider": {
+    "message": "AI Provider"
+  },
+  "selectAiProvider": {
+    "message": "Select AI Provider"
+  },
   "settingsSavedSuccess": {
     "message": "Settings saved successfully!"
   },

--- a/packages/i18n/locales/ja/messages.json
+++ b/packages/i18n/locales/ja/messages.json
@@ -55,6 +55,12 @@
   "githubIntegration": {
     "message": "GitHub連携"
   },
+  "aiProvider": {
+    "message": "利用するAI"
+  },
+  "selectAiProvider": {
+    "message": "利用するAIを選択してください。"
+  },
   "settingsSavedSuccess": {
     "message": "設定が正常に保存されました！"
   },

--- a/packages/i18n/locales/ko/messages.json
+++ b/packages/i18n/locales/ko/messages.json
@@ -39,6 +39,12 @@
   "githubIntegration": {
     "message": "GitHub 연동"
   },
+  "aiProvider": {
+    "message": "AI 제공자"
+  },
+  "selectAiProvider": {
+    "message": "AI 제공자를 선택하세요."
+  },
   "settingsSavedSuccess": {
     "message": "설정이 성공적으로 저장되었습니다!"
   },

--- a/packages/i18n/locales/zh/messages.json
+++ b/packages/i18n/locales/zh/messages.json
@@ -55,6 +55,12 @@
   "githubIntegration": {
     "message": "GitHub集成"
   },
+  "aiProvider": {
+    "message": "AI提供者"
+  },
+  "selectAiProvider": {
+    "message": "选择AI提供者"
+  },
   "settingsSavedSuccess": {
     "message": "设置已成功保存！"
   },

--- a/pages/side-panel/src/views/SettingsView.tsx
+++ b/pages/side-panel/src/views/SettingsView.tsx
@@ -133,9 +133,9 @@ const SettingsView: React.FC = () => {
         </div>
 
         <div className="bg-white rounded-lg shadow-md p-6 mb-6">
-          <h2 className="text-lg font-semibold mb-4">AI Provider</h2>
+          <h2 className="text-lg font-semibold mb-4">{t('aiProvider')}</h2>
           <label htmlFor="modelClientType" className="block text-sm font-medium text-gray-700 mb-1">
-            Select AI Provider
+            {t('selectAiProvider')}
           </label>
           <select
             id="modelClientType"


### PR DESCRIPTION
## Summary
- internationalize `AI Provider` labels
- add translations for Japanese, Korean, Chinese, and English locales

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68713f6640a4832bbebee43f310b1bb4