### PR TITLE
Fix dynamic language update on PR analysis screen

### DIFF
--- a/pages/side-panel/src/components/ChecklistComponent.tsx
+++ b/pages/side-panel/src/components/ChecklistComponent.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useState } from 'react';
 import type { Checklist } from '../types';
 import { MarkdownRenderer } from './MarkdownRenderer';
-import { t } from '@extension/i18n';
+import { useI18n } from '@extension/i18n';
 
 interface ChecklistComponentProps {
   checklist: Checklist;
@@ -93,6 +93,7 @@ const ChecklistComponent = ({
   className = '',
   defaultExpanded = true,
 }: ChecklistComponentProps) => {
+  const { t } = useI18n();
   const [expanded, setExpanded] = useState(defaultExpanded);
 
   const handleCopy = async (text: string): Promise<boolean> => {

--- a/pages/side-panel/src/components/FileChatModal.tsx
+++ b/pages/side-panel/src/components/FileChatModal.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import type { PRFile, PRAnalysisResult } from '../types';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import ChecklistComponent from './ChecklistComponent';
-import { t } from '@extension/i18n';
+import { useI18n } from '@extension/i18n';
 
 interface FileChatModalProps {
   open: boolean;
@@ -33,6 +33,7 @@ const FileChatModal: React.FC<FileChatModalProps> = ({
   onChecklistChange,
   analysisResult,
 }) => {
+  const { t } = useI18n();
   const [input, setInput] = useState('');
   const [streaming, setStreaming] = useState(false);
   const [streamedMessage, setStreamedMessage] = useState('');

--- a/pages/side-panel/src/components/FileChecklist.tsx
+++ b/pages/side-panel/src/components/FileChecklist.tsx
@@ -6,7 +6,7 @@ import { fetchers } from '@src/services/aiService';
 import type { Language } from '@extension/storage';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import ChecklistComponent from './ChecklistComponent';
-import { t } from '@extension/i18n';
+import { useI18n } from '@extension/i18n';
 
 interface FileChecklistProps {
   file: PRData['files'][0];
@@ -33,6 +33,7 @@ const FileChecklist = ({
 }: FileChecklistProps) => {
   const [generating, setGenerating] = useState(false);
   const setGlobalGenerating = useSetAtom(generatingAtom);
+  const { t } = useI18n();
   const [error, setError] = useState<string | null>(null);
   const [blockActive, setBlockActive] = useState(0);
   const blockTimer = useRef<NodeJS.Timeout | null>(null);

--- a/pages/side-panel/src/components/Header.tsx
+++ b/pages/side-panel/src/components/Header.tsx
@@ -1,6 +1,7 @@
-import { t } from '@extension/i18n';
+import { useI18n } from '@extension/i18n';
 
 const Header = () => {
+  const { t } = useI18n();
   return (
     <div className="flex justify-between items-center p-2 bg-gray-100 border-b border-gray-300 mb-4">
       <div className="cursor-pointer">

--- a/pages/side-panel/src/components/PRAnalysis.tsx
+++ b/pages/side-panel/src/components/PRAnalysis.tsx
@@ -1,14 +1,12 @@
 import { useState, useEffect } from 'react';
 import { useAtom } from 'jotai';
 import type { Checklist, PRAnalysisResult, PRData } from '../types';
-import type { Language } from '@extension/storage';
-import { defaultLanguage, languagePreferenceStorage } from '@extension/storage';
 import { fetchers } from '@src/services/aiService';
 import FileChatModal from './FileChatModal';
 import { generatingAtom } from '@src/atoms/generatingAtom';
 import FileChecklist from './FileChecklist';
 import { MarkdownRenderer } from './MarkdownRenderer';
-import { t } from '@extension/i18n';
+import { useI18n } from '@extension/i18n';
 
 interface PRAnalysisProps {
   prData: PRData;
@@ -28,7 +26,7 @@ const PRAnalysis: React.FC<PRAnalysisProps> = ({
   const [, setGenerating] = useAtom(generatingAtom);
   // summaryのgenerateを管理
   const [summaryGenerating, setSummaryGenerating] = useState(false);
-  const [language, setLanguage] = useState<Language>(defaultLanguage); // デフォルト言語を設定
+  const { language, t } = useI18n();
   const [error, setError] = useState<string | null>(null);
   const [chatModalOpen, setChatModalOpen] = useState<string | null>(null);
   const [chatHistories, setChatHistories] = useState<Record<string, { sender: string; message: string }[]>>(() => {
@@ -38,18 +36,6 @@ const PRAnalysis: React.FC<PRAnalysisProps> = ({
     }
     return {};
   });
-
-  // 言語設定を読み込む
-  useEffect(() => {
-    const loadLanguage = async () => {
-      const savedLanguage = await languagePreferenceStorage.get();
-      if (savedLanguage) {
-        setLanguage(savedLanguage);
-      }
-    };
-
-    loadLanguage();
-  }, []);
 
   // チャット履歴をローカルストレージに保存
   useEffect(() => {

--- a/pages/side-panel/src/components/StorageManagement.tsx
+++ b/pages/side-panel/src/components/StorageManagement.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
-import { t } from '@extension/i18n';
+import { useI18n } from '@extension/i18n';
 
 // Component for storage management (clear PR data)
 const StorageManagement = () => {
+  const { t } = useI18n();
   const [isClearing, setIsClearing] = useState(false);
   const [message, setMessage] = useState({ text: '', type: '' });
   const [hasPrData, setHasPRData] = useState(false);


### PR DESCRIPTION
## Summary
- refresh PR analysis components when language changes
- use `useI18n` hook instead of static translations

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6871e5668380832bb4a698dba9e629ff