### PR TITLE
Update token setup text

### DIFF
--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -3,7 +3,7 @@ import 'webextension-polyfill';
 // Add event listener to open side panel when extension icon is clicked
 chrome.action.onClicked.addListener(async tab => {
   // Open the side panel in the current tab
-  await chrome.sidePanel.open({ tabId: tab.id });
+  await chrome.sidePanel.open({ tabId: tab.id, windowId: tab.windowId });
   console.log('Side panel opened for tab:', tab.id);
 });
 

--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -83,7 +83,7 @@
     "message": "Your GitHub token is stored locally and only used to access PR data."
   },
   "createGithubToken": {
-    "message": "Create a new token on GitHub →"
+    "message": "Create a personal access token on GitHub →"
   },
   "githubApiDomain": {
     "message": "GitHub API Domain"

--- a/packages/i18n/locales/ja/messages.json
+++ b/packages/i18n/locales/ja/messages.json
@@ -83,7 +83,7 @@
     "message": "GitHubトークンはローカルに保存され、PRデータへのアクセスにのみ使用されます。"
   },
   "createGithubToken": {
-    "message": "GitHubで新しいトークンを作成 →"
+    "message": "GitHubで個人用アクセス トークンを作成 →"
   },
   "githubApiDomain": {
     "message": "GitHub APIドメイン"

--- a/packages/i18n/locales/ko/messages.json
+++ b/packages/i18n/locales/ko/messages.json
@@ -67,7 +67,7 @@
     "message": "GitHub 토큰은 로컬에 저장되며 PR 데이터에 액세스하는 데만 사용됩니다."
   },
   "createGithubToken": {
-    "message": "GitHub에서 새 토큰 만들기 →"
+    "message": "GitHub에서 개인 액세스 토큰 만들기 →"
   },
   "githubApiDomain": {
     "message": "GitHub API 도메인"

--- a/packages/i18n/locales/zh/messages.json
+++ b/packages/i18n/locales/zh/messages.json
@@ -83,7 +83,7 @@
     "message": "您的GitHub令牌存储在本地，仅用于访问PR数据。"
   },
   "createGithubToken": {
-    "message": "在GitHub上创建新令牌 →"
+    "message": "在GitHub上创建个人访问令牌 →"
   },
   "githubApiDomain": {
     "message": "GitHub API域名"

--- a/pages/side-panel/src/types/index.ts
+++ b/pages/side-panel/src/types/index.ts
@@ -89,6 +89,7 @@ export interface ChecklistItem {
   id: string;
   description: string;
   isChecked: boolean;
+  status?: 'OK' | 'NG' | 'PENDING';
 }
 
 // ファイルチェックリストの型

--- a/pages/side-panel/src/utils/envUtils.ts
+++ b/pages/side-panel/src/utils/envUtils.ts
@@ -3,7 +3,7 @@ export function isGeminiApiEnabled(): boolean {
   // Vite exposes env vars on import.meta.env
   // Fallback for test: check process.env as well
   const endpoint =
-    (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_GEMINI_API_ENDPOINT) ||
+    (typeof import.meta !== 'undefined' && (import.meta as any).env && (import.meta as any).env.VITE_GEMINI_API_ENDPOINT) ||
     (typeof process !== 'undefined' && process.env && process.env.VITE_GEMINI_API_ENDPOINT);
   return !!(endpoint && typeof endpoint === 'string' && endpoint.trim() !== '' && endpoint !== 'undefined');
 }

--- a/pages/side-panel/src/views/GithubTokenSetupView.tsx
+++ b/pages/side-panel/src/views/GithubTokenSetupView.tsx
@@ -45,7 +45,8 @@ const GithubTokenSetupView: React.FC = () => {
       <div className="bg-white p-6 rounded-lg shadow-lg max-w-md w-full">
         <h2 className="text-xl font-bold mb-4">GitHub Token Setup</h2>
         <p className="text-sm mb-4">
-          To use PR Checklistify, you need to provide a GitHub Personal Access Token with 'repo' scope permissions.
+          To use PR Checklistify, you need to provide a GitHub Personal Access Token with
+          <code>repo</code> scope permissions.
         </p>
 
         <div className="mb-4">
@@ -54,7 +55,7 @@ const GithubTokenSetupView: React.FC = () => {
             target="_blank"
             rel="noreferrer"
             className="text-blue-500 hover:text-blue-700 text-sm">
-            Create a new token on GitHub →
+            Create a personal access token on GitHub →
           </a>
         </div>
 


### PR DESCRIPTION
## Summary
- update instructions for GitHub token setup to mention personal access tokens
- adjust env utils type-safety and include status field for checklist items
- fix side panel open logic for Chrome type error

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_6871e42a18ac832b95982dacdd4846bb