### PR TITLE
Fix import path in module manager

### DIFF
--- a/packages/module-manager/index.mts
+++ b/packages/module-manager/index.mts
@@ -1,3 +1,3 @@
-import runModuleManager from 'lib/runModuleManager.ts';
+import runModuleManager from './lib/runModuleManager.ts';
 
 void runModuleManager();


### PR DESCRIPTION
## Summary
- fix module manager entrypoint import path

## Testing
- `TURBO_TELEMETRY_DISABLED=1 pnpm lint`
- `pnpm e2e` *(fails: ENETUNREACH to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687cdbe8b4c4832baa26cae776fe7cf7