### PR TITLE
Refactor UI with reusable components

### DIFF
--- a/pages/side-panel/src/components/atoms/CenteredCard.tsx
+++ b/pages/side-panel/src/components/atoms/CenteredCard.tsx
@@ -1,0 +1,15 @@
+import type React from 'react';
+
+interface CenteredCardProps {
+  children: React.ReactNode;
+  cardClassName?: string;
+  containerClassName?: string;
+}
+
+const CenteredCard: React.FC<CenteredCardProps> = ({ children, cardClassName = '', containerClassName = '' }) => (
+  <div className={`flex items-center justify-center min-h-screen p-6 bg-gray-50 ${containerClassName}`}>
+    <div className={`bg-white p-6 rounded-lg shadow-lg w-full ${cardClassName}`}>{children}</div>
+  </div>
+);
+
+export default CenteredCard;

--- a/pages/side-panel/src/components/atoms/index.ts
+++ b/pages/side-panel/src/components/atoms/index.ts
@@ -1,3 +1,4 @@
 export { default as Button } from './Button';
 export { default as Toast } from './Toast';
 export { default as ChecklistItem } from './ChecklistItem';
+export { default as CenteredCard } from './CenteredCard';

--- a/pages/side-panel/src/components/templates/UnifiedApiKeySetupView.tsx
+++ b/pages/side-panel/src/components/templates/UnifiedApiKeySetupView.tsx
@@ -7,7 +7,7 @@ import { useGeminiModelAtom } from '@src/hooks/useGeminiModelAtom';
 import { useClaudeModelAtom } from '@src/hooks/useClaudeModelAtom';
 import { useModelClientTypeAtom } from '@src/hooks/useModelClientTypeAtom';
 import { isGeminiApiEnabled } from '@src/utils/envUtils';
-import { Button } from '@src/components/atoms';
+import { Button, CenteredCard } from '@src/components/atoms';
 import { ApiProviderSelector } from '@src/components/molecules';
 import { ApiKeyConfiguration } from '@src/components/organisms';
 
@@ -107,17 +107,15 @@ const UnifiedApiKeySetupView: React.FC<UnifiedApiKeySetupViewProps> = ({ mode = 
   // セットアップモード用のレイアウト
   if (mode === 'setup') {
     return (
-      <div className="flex items-center justify-center h-screen p-6 bg-gray-50">
-        <div className="bg-white p-6 rounded-lg shadow-lg max-w-md w-full">
-          <h2 className="text-xl font-bold mb-4">{t('apiKeySetup')}</h2>
-          {renderContent()}
-          <div className="mt-6 flex justify-end">
-            <Button onClick={navigateToHome} variant="primary" disabled={!isApiKeySet()}>
-              {t('next')}
-            </Button>
-          </div>
+      <CenteredCard cardClassName="max-w-md">
+        <h2 className="text-xl font-bold mb-4">{t('apiKeySetup')}</h2>
+        {renderContent()}
+        <div className="mt-6 flex justify-end">
+          <Button onClick={navigateToHome} variant="primary" disabled={!isApiKeySet()}>
+            {t('next')}
+          </Button>
         </div>
-      </div>
+      </CenteredCard>
     );
   }
 

--- a/pages/side-panel/src/views/GithubTokenSetupView.tsx
+++ b/pages/side-panel/src/views/GithubTokenSetupView.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@extension/i18n';
 import { useOpenaiKeyAtom } from '@src/hooks/useOpenaiKeyAtom';
 import { useGithubTokensAtom } from '@src/hooks/useGithubTokensAtom';
 import GitHubIntegrationSettings from '@src/components/organisms/GitHubIntegrationSettings';
+import { CenteredCard, Toast } from '@src/components/atoms';
 import { useNavigation } from './NavigationContext';
 
 const GithubTokenSetupView: React.FC = () => {
@@ -33,50 +34,42 @@ const GithubTokenSetupView: React.FC = () => {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen p-6 bg-gray-50">
-      <div className="bg-white p-6 rounded-lg shadow-lg max-w-2xl w-full">
-        <div className="mb-6">
-          <h2 className="text-xl font-bold mb-4">{t('githubIntegration')} Setup</h2>
-          <p className="text-sm mb-4 text-gray-600" dangerouslySetInnerHTML={{ __html: t('githubSetupDescription') }} />
-          {hasGitHubToken && (
-            <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg">
-              <p className="text-sm text-green-800">✓ {t('githubTokensConfigured')}</p>
-            </div>
-          )}
-        </div>
-
-        <div className="mb-6">
-          <GitHubIntegrationSettings onToast={handleToast} />
-        </div>
-
-        <div className="flex justify-end">
-          <button
-            onClick={handleContinue}
-            disabled={!hasGitHubToken}
-            className={`px-4 py-2 rounded-lg transition-colors ${
-              hasGitHubToken
-                ? 'bg-blue-500 text-white hover:bg-blue-600'
-                : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-            }`}>
-            {t('continueSetup')}
-          </button>
-        </div>
-
-        {/* Toast Message */}
-        {toastMessage && (
-          <div
-            className={`fixed top-4 right-4 p-3 rounded-lg shadow-lg z-50 ${
-              toastMessage.type === 'success'
-                ? 'bg-green-500 text-white'
-                : toastMessage.type === 'error'
-                  ? 'bg-red-500 text-white'
-                  : 'bg-blue-500 text-white'
-            }`}>
-            {toastMessage.message}
+    <CenteredCard cardClassName="max-w-2xl">
+      <div className="mb-6">
+        <h2 className="text-xl font-bold mb-4">{t('githubIntegration')} Setup</h2>
+        <p className="text-sm mb-4 text-gray-600" dangerouslySetInnerHTML={{ __html: t('githubSetupDescription') }} />
+        {hasGitHubToken && (
+          <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg">
+            <p className="text-sm text-green-800">✓ {t('githubTokensConfigured')}</p>
           </div>
         )}
       </div>
-    </div>
+
+      <div className="mb-6">
+        <GitHubIntegrationSettings onToast={handleToast} />
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          onClick={handleContinue}
+          disabled={!hasGitHubToken}
+          className={`px-4 py-2 rounded-lg transition-colors ${
+            hasGitHubToken ? 'bg-blue-500 text-white hover:bg-blue-600' : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+          }`}>
+          {t('continueSetup')}
+        </button>
+      </div>
+
+      {/* Toast Message */}
+      {toastMessage && (
+        <Toast
+          message={toastMessage.message}
+          type={toastMessage.type}
+          visible={!!toastMessage}
+          onClose={() => setToastMessage(null)}
+        />
+      )}
+    </CenteredCard>
   );
 };
 


### PR DESCRIPTION
## Summary
- create `CenteredCard` atom for consistent centered layouts
- reuse `CenteredCard` in unified API key setup view
- refactor Github token setup view to use `CenteredCard` and existing `Toast` atom

## Testing
- `pnpm lint`
- `pnpm prettier`
- `pnpm type-check` *(fails: command exited with code 2)*

------
https://chatgpt.com/codex/tasks/task_e_687d13b41e84832b9d4000fcb7f6a5b7